### PR TITLE
Add an error-log for unexpected exceptions during loading

### DIFF
--- a/src/tech/v3/jna/base.clj
+++ b/src/tech/v3/jna/base.clj
@@ -4,6 +4,7 @@
   (:import [com.sun.jna Native NativeLibrary Pointer Function Platform]
            [com.sun.jna.ptr PointerByReference]
            [java.lang.reflect Method]
+           [java.lang UnsatisfiedLinkError]
            [java.io File]))
 
 (set! *warn-on-reflection* true)
@@ -150,7 +151,9 @@
                            (try
                              [pathname load-path
                               (NativeLibrary/getInstance load-path)]
-                             (catch Throwable _))))
+                             (catch UnsatisfiedLinkError _)
+                             (catch Throwable ex
+                               (log/error ex)))))
                     (remove nil?)
                     first)]
     (when-not retval

--- a/test/tech/v3/jna_test.clj
+++ b/test/tech/v3/jna_test.clj
@@ -31,3 +31,16 @@
         dst (jna/malloc strlen)]
     (strcpy dst src)
     (is (= src-str (jna/variable-byte-ptr->string dst)))))
+
+(jna/def-jna-fn "doesnt-exist" phantom
+ "Verify that a unloadable library is handled gracefully"
+ Pointer
+ [dest jna/ensure-ptr]
+ [src jna/ensure-ptr])
+
+(deftest phantom-test
+  (let [src-str "dog jumped over moon"
+        strlen (inc (count src-str))
+        src (jna/string->ptr src-str)
+        dst (jna/malloc strlen)]
+    (is (thrown? clojure.lang.ExceptionInfo (phantom dst src)))))


### PR DESCRIPTION
Hello,

I recently ran into an issue with an unloadable ELF.  It was really hard to find, initially because tech.jna was burying all exceptions and treating bad .so files the same as not-found.  This patch changes the behavior where not-found should be handled similar as before, but other, presumably more unexpected exceptions get a SEVERE error log.