### PR TITLE
Memoize the find-function path

### DIFF
--- a/src/tech/v3/jna/base.clj
+++ b/src/tech/v3/jna/base.clj
@@ -210,8 +210,8 @@ native libraries under this location:"
 
 
 (def do-find-function
-  (fn [fn-name libname]
-    (.getFunction ^NativeLibrary (load-library libname) fn-name)))
+  (memoize (fn [fn-name libname]
+             (.getFunction ^NativeLibrary (load-library libname) fn-name))))
 
 
 (defn find-function


### PR DESCRIPTION
Function lookup shows up as significant overhead in anything that uses tech.jna in the hotpath

Signed-off-by: Greg Haskins <greg@manetu.com>