### PR TITLE
Bump Version of JNI

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure      "1.10.1-beta2"]
-                 [net.java.dev.jna/jna     "5.6.0"]
+                 [net.java.dev.jna/jna     "5.12.1"]
                  [techascent/tech.resource "5.02"]]
   :profiles {:codox
              {:dependencies [[codox-theme-rdash "0.1.2"]]


### PR DESCRIPTION
This is necessary for the library to work on m-series macbooks

(https://stackoverflow.com/questions/70368863/unsatisfiedlinkerror-for-m1-macs-while-running-play-server-locally)